### PR TITLE
fix: 🐛 module resolution with rspack

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "main": "./lib/index.js",
   "module": "./module/index.js",
   "typings": "./lib/index.d.ts",
+  "style": "./_index.scss",
   "files": [
     "_index.scss",
     "lib",


### PR DESCRIPTION
Since rspack@1.0.0-alpha.3, we have been facing an issue where modules cannot be resolved correctly.
We've found that adding a style field to the package.json file can help avoid this issue.
This PR aims to enable module resolution in rspack as intended. However, since it follows the approach proposed in the Sass RFC for the [package importer](https://sass-lang.com/blog/rfc-package-importer/), we expect it to serve as a universal solution to the problem, not limited to rspack.

see: https://github.com/web-infra-dev/rspack/issues/8057
