### PR TITLE
fix: resolve sass-loader warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .idea
 lib
 module

--- a/_index.scss
+++ b/_index.scss
@@ -183,7 +183,8 @@ $-HIDDEN_MODE_OPACITY: "opacity";
 
 // 円形塗りのタイプ
 @mixin show-circle($args...) {
-  @include show-square($args..., $border-radius: 50%) {
+  $rest: (border-radius: 50%);
+  @include show-square($args..., $rest...) {
     @content;
   }
 }

--- a/src/atoms/svg/Svg.stories.tsx
+++ b/src/atoms/svg/Svg.stories.tsx
@@ -38,7 +38,7 @@ export const StylingPattern = () => (
   <>
     <section>
       <h1>Plane & Fill</h1>
-      <SVG defaultName="Svg" className={nameDefaultClassNames.plane} />
+      <SVG defaultName="StorybookIcon" className={nameDefaultClassNames.plane} />
       &nbsp;
       <SVG className={nameSvgClassNames.plane} />
       &nbsp;
@@ -48,7 +48,7 @@ export const StylingPattern = () => (
     </section>
     <section>
       <h1>+ Background</h1>
-      <SVG defaultName="Svg" className={nameDefaultClassNames.circle} />
+      <SVG defaultName="StorybookIcon" className={nameDefaultClassNames.circle} />
       &nbsp;
       <SVG className={nameSvgClassNames.circle} />
       &nbsp;
@@ -56,7 +56,7 @@ export const StylingPattern = () => (
       &nbsp;
       <SVG className={nameSvgClassNames.circleFill} />
       <br />
-      <SVG defaultName="Svg" className={nameDefaultClassNames.square} />
+      <SVG defaultName="StorybookIcon" className={nameDefaultClassNames.square} />
       &nbsp;
       <SVG className={nameSvgClassNames.square} />
       &nbsp;
@@ -66,7 +66,7 @@ export const StylingPattern = () => (
     </section>
     <section>
       <h1>+ Border</h1>
-      <SVG defaultName="Svg" className={nameDefaultClassNames.circleBorder} />
+      <SVG defaultName="StorybookIcon" className={nameDefaultClassNames.circleBorder} />
       &nbsp;
       <SVG className={nameSvgClassNames.circleBorder} />
       &nbsp;
@@ -77,7 +77,7 @@ export const StylingPattern = () => (
       &nbsp;
       <SVG className={nameSvgClassNames.circleFillBorder} />
       <br />
-      <SVG defaultName="Svg" className={nameDefaultClassNames.squareBorder} />
+      <SVG defaultName="StorybookIcon" className={nameDefaultClassNames.squareBorder} />
       &nbsp;
       <SVG className={nameSvgClassNames.squareBorder} />
       &nbsp;

--- a/src/atoms/svg/Svg.tsx
+++ b/src/atoms/svg/Svg.tsx
@@ -4,7 +4,7 @@ export type SvgProps = ExtractProps<typeof SVG>;
 export const { SVG, pathMap } = setup({
   React: () => "https://cdn.svgporn.com/logos/react.svg",
   Sass: () => "https://cdn.svgporn.com/logos/sass.svg",
-  Svg: () => "https://cdn.svgporn.com/logos/svg.svg",
+  StorybookIcon: () => "https://cdn.svgporn.com/logos/storybook-icon.svg",
 
   AndroidIcon: () => "https://cdn.svgporn.com/logos/android-icon.svg",
   Apple: () => "https://cdn.svgporn.com/logos/apple.svg",
@@ -53,7 +53,6 @@ export const { SVG, pathMap } = setup({
   SlackIcon: () => "https://cdn.svgporn.com/logos/slack-icon.svg",
   StackoverflowIcon: () =>
     "https://cdn.svgporn.com/logos/stackoverflow-icon.svg",
-  StorybookIcon: () => "https://cdn.svgporn.com/logos/storybook-icon.svg",
   Terminal: () => "https://cdn.svgporn.com/logos/terminal.svg",
   TiktokIcon: () => "https://cdn.svgporn.com/logos/tiktok-icon.svg",
   Twitter: () => "https://cdn.svgporn.com/logos/twitter.svg",

--- a/src/atoms/svg/name-default.module.scss
+++ b/src/atoms/svg/name-default.module.scss
@@ -8,7 +8,7 @@ $background-image: linear-gradient(180deg, #eee 0%, #888 100%);
 }
 
 .plane-fill {
-  @include show(null, 56px, #000);
+  @include show(null, 56px, #00f);
 }
 
 // circle
@@ -17,7 +17,7 @@ $background-image: linear-gradient(180deg, #eee 0%, #888 100%);
 }
 
 .circle-fill {
-  @include show-circle(null, 56px, #ddd, #000);
+  @include show-circle(null, 56px, #ddd, #00f);
 }
 
 .circle-border {
@@ -25,7 +25,7 @@ $background-image: linear-gradient(180deg, #eee 0%, #888 100%);
 }
 
 .circle-fill-border {
-  @include show-circle(null, 56px, #ddd, #000, $border-width: 4px);
+  @include show-circle(null, 56px, #ddd, #00f, $border-width: 4px);
 }
 
 // square
@@ -38,7 +38,7 @@ $background-image: linear-gradient(180deg, #eee 0%, #888 100%);
     null,
     56px,
     $background-image: $background-image,
-    $fill-color: #000
+    $fill-color: #00f
   );
 }
 
@@ -57,6 +57,6 @@ $background-image: linear-gradient(180deg, #eee 0%, #888 100%);
     56px,
     $border-width: 4px,
     $background-image: $background-image,
-    $fill-color: #000
+    $fill-color: #00f
   );
 }

--- a/src/atoms/svg/name.module.scss
+++ b/src/atoms/svg/name.module.scss
@@ -4,33 +4,33 @@ $background-image: linear-gradient(180deg, #eee 0%, #888 100%);
 
 // plane
 .plane {
-  @include show($Svg, 56px);
+  @include show($StorybookIcon, 56px);
 }
 
 .plane-fill {
-  @include show($React, 56px, #000);
+  @include show($React, 56px, #00f);
 }
 
 // circle
 .circle {
-  @include show-circle($Svg, 56px, #ddd);
+  @include show-circle($StorybookIcon, 56px, #ddd);
 }
 
 .circle-fill {
-  @include show-circle($React, 56px, #ddd, #000);
+  @include show-circle($React, 56px, #ddd, #00f);
 }
 
 .circle-border {
-  @include show-circle($Svg, 56px, #ddd, $border-width: 4px);
+  @include show-circle($StorybookIcon, 56px, #ddd, $border-width: 4px);
 }
 
 .circle-fill-border {
-  @include show-circle($React, 56px, #ddd, #000, $border-width: 4px);
+  @include show-circle($React, 56px, #ddd, #00f, $border-width: 4px);
 }
 
 // square
 .square {
-  @include show-square($Svg, 56px, $background-image: $background-image);
+  @include show-square($StorybookIcon, 56px, $background-image: $background-image);
 }
 
 .square-fill {
@@ -38,13 +38,13 @@ $background-image: linear-gradient(180deg, #eee 0%, #888 100%);
     $React,
     56px,
     $background-image: $background-image,
-    $fill-color: #000
+    $fill-color: #00f
   );
 }
 
 .square-border {
   @include show-square(
-    $Svg,
+    $StorybookIcon,
     56px,
     $border-width: 4px,
     $background-image: $background-image
@@ -57,6 +57,6 @@ $background-image: linear-gradient(180deg, #eee 0%, #888 100%);
     56px,
     $border-width: 4px,
     $background-image: $background-image,
-    $fill-color: #000
+    $fill-color: #00f
   );
 }

--- a/src/templates/example/Example.tsx
+++ b/src/templates/example/Example.tsx
@@ -14,7 +14,7 @@ export const Example = () => {
         <SVG className={classNames.svg} /> Sass
       </button>
       <button className={classNames.button}>
-        <SVG /> SVG
+        <SVG /> Storybook
       </button>
       <button className={classNames.button}>
         <SVG /> NULL

--- a/src/templates/example/example.module.scss
+++ b/src/templates/example/example.module.scss
@@ -15,7 +15,7 @@
   }
 
   &:active .svg {
-    @include svg.show(svg.$Svg); // ボタンを押下するとSVGのロゴを表示する
+    @include svg.show(svg.$StorybookIcon); // ボタンを押下するとStorybookのロゴを表示する
   }
 }
 
@@ -27,12 +27,12 @@
   }
 
   &:hover .svg {
-    @include svg.show(svg.$Svg);
+    @include svg.show(svg.$StorybookIcon);
   }
 
   &:hover .svg,
     // チラツキ防止用のセレクタ(ホバー終了後、まだSVGが書き換わっていない瞬間)
-    &:not(:hover) .svg[data-svg-name="#{svg.$Svg}"] {
+    &:not(:hover) .svg[data-svg-name="#{svg.$StorybookIcon}"] {
     fill: gray; // ボタンにホバーするとSVGの色が変わる
   }
 
@@ -46,7 +46,7 @@
 
   &:nth-of-type(3) {
     > svg {
-      @include svg.show(svg.$Svg, 0.8em); // Sassのロゴを表示する
+      @include svg.show(svg.$StorybookIcon, 0.8em); // Storybookのロゴを表示する
     }
 
     &:hover > svg {


### PR DESCRIPTION
sass-loaderで出る「rest形式の引数は後方から順に設定されている必要がある」という以下を解消。

```
Named arguments must come before rest arguments.
This will be an error in Dart Sass 2.0.0.

@include show-square($args..., $border-radius: 50%) {
```